### PR TITLE
GA-23 - Fix docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,6 @@ x-superset-user: &superset-user root
 x-superset-volumes: &superset-volumes
   # /app/pythonpath_docker will be appended to the PYTHONPATH in the final container
   - ./docker:/app/docker
-  - ./superset:/app/superset
-  - ./superset-frontend:/app/superset-frontend
   - superset_home:/app/superset_home
   - ./tests:/app/tests
 


### PR DESCRIPTION
Проблема была в том, что в `x-superset-volumes` были ./superset:/app/superset и ./superset-frontend:/app/superset-frontend, которые у нас пустые и они перезаписывали то, что шло в образе, из-за чего superset_init не мог найти банарь superset